### PR TITLE
UI Color Palette /one /figma 5.1.4 Syrah

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11833,7 +11833,7 @@
       }
     },
     "packages/ui-ui-color-palette": {
-      "version": "2.2.2",
+      "version": "2.2.3",
       "license": "MIT",
       "workspaces": [
         "packages/announcements-yelbolt-worker",


### PR DESCRIPTION
Upgrade the ui-ui-color-palette package to version 2.2.3 and update the subproject commit reference.